### PR TITLE
fix: update doc, fix pinata error, add PORT env

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ to the client. Currently, the supported storages are:
 
 - AWS S3 bucket
 - Local storage
+- Pinata Storage
 
 The metadata file should be named based on the token ID of the metadata 
 (e.g. "1.json"). We can find the example in the `tests/test_file/metadata`
@@ -30,6 +31,7 @@ source env/bin/activate
 3. Run `pip install -r requirements.txt` to install dependencies
 4. Set the following environment variables
    - `MAX_TOKEN_ID`: The maximum token ID of metadata available
+   - `SECRET_KEY`: Secret key to validate JWT
    - `METADATA_FOLDER`: The folder containing metadata files, leave empty if it's stored in the root directory
    - `S3_BUCKET_NAME`: The AWS S3 bucket name that used to store metadata
    - `STORAGE_ACCESS_KEY`: The AWS access key to access S3 bucket
@@ -50,6 +52,34 @@ source env/bin/activate
 3. Run `pip install -r requirements.txt` to install dependencies
 4. Set the following environment variables
     - `MAX_TOKEN_ID`: The maximum token ID of metadata available
+    - `SECRET_KEY`: Secret key to validate JWT
     - `METADATA_FOLDER`: The folder containing metadata files, leave empty if it's stored in the root directory
     - `STORAGE_TYPE`: Set `local` if using local storage
 5. Run `python main.py` to start the server
+
+### Read metadata from Pinata storage
+
+1. Create directory to store metadata within the project directory and save the metadata files there
+2. Go to the project directory and create Python virtual environment
+
+```
+python3 -m venv env
+source env/bin/activate
+```
+
+3. Run `pip install -r requirements.txt` to install dependencies
+4. Set the following environment variables
+    - `MAX_TOKEN_ID`: The maximum token ID of metadata available
+    - `SECRET_KEY`: Secret key to validate JWT
+    - `STORAGE_ACCESS_KEY`: The Pinata access key
+    - `STORAGE_SECRET_KEY`: The Pinata secret key
+    - `STORAGE_TYPE`: Set `pinata` if using pinata storage
+5. Run `python main.py` to start the server
+
+## How To Test
+
+To run the test, run the following script
+
+```sh
+sh test.sh
+```

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 import uuid
 
+import uvicorn
 from fastapi import FastAPI, Request, Response
 
 from module.constant import CORRELATION_ID
+from module.env import Env
 from routers.router import router
 
 app = FastAPI()
@@ -25,3 +27,6 @@ async def set_correlation_id(request: Request, call_next):
 
 
 router(app)
+
+if __name__ == "__main__":  # pragma: no cover
+    uvicorn.run(app, host="0.0.0.0", port=Env.PORT)

--- a/module/env.py
+++ b/module/env.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     STORAGE_ACCESS_KEY: Optional[str] = ""
     STORAGE_SECRET_KEY: Optional[str] = ""
     STORAGE_TYPE: StorageType
+    PORT: Optional[int] = 3000
 
 
 Env = Settings()  # Import this variable to get the environment variable value

--- a/module/storage/pinata.py
+++ b/module/storage/pinata.py
@@ -19,6 +19,7 @@ class PinataStorage(StorageInterface):
 
     timeout = aiohttp.ClientTimeout(total=10)
 
+    @validate_arguments(config=dict(arbitrary_types_allowed=True))
     def __init__(self, logger: logging.Logger, config: dict, **kwargs):
         """Initialize Pinata Storage class
 


### PR DESCRIPTION
This PR will update the documentation and the code so it's able to run the server in the docker and configure the PORT through environment variable.
There was an error in Pinata when parsing configuration and it's fixed in this PR.

## Test

### Unit Test

```
----------------------------------------------------------------------
Ran 87 tests in 0.200s

OK
Name                                           Stmts   Miss  Cover
------------------------------------------------------------------
config.py                                         11      0   100%
controller/internal_metadata.py                   25      0   100%
controller/metadata.py                             4      0   100%
main.py                                           17      0   100%
module/auth.py                                    13      0   100%
module/constant.py                                 7      0   100%
module/env.py                                     16      0   100%
module/logger.py                                  13      0   100%
module/response.py                                11      0   100%
module/schema/metadata.py                         18      0   100%
module/schema/storage.py                          11      0   100%
module/storage/local.py                           62      0   100%
module/storage/main.py                            25      0   100%
module/storage/pinata.py                         116      3    97%
module/storage/s3.py                              76      0   100%
module/storage/storage_interface.py                1      0   100%
module/utils.py                                   95      0   100%
routers/__init__.py                                0      0   100%
routers/health.py                                  5      0   100%
routers/internal_metadata.py                      12      0   100%
routers/metadata.py                               10      0   100%
routers/router.py                                  6      0   100%
tests/__init__.py                                  0      0   100%
tests/constant.py                                  3      0   100%
tests/mock_class.py                               49      0   100%
tests/test_create_backup.py                       22      0   100%
tests/test_flatten_attribute.py                   17      0   100%
tests/test_get_metadata.py                        27      0   100%
tests/test_get_metadata_endpoint.py               29      0   100%
tests/test_healthcheck.py                          9      0   100%
tests/test_put_internal_metadata_endpoint.py      73      0   100%
tests/test_save_metadata.py                       37      0   100%
tests/test_storage_local.py                      103      0   100%
tests/test_storage_pinata.py                     137     11    92%
tests/test_storage_s3.py                         121      0   100%
tests/test_update_attribute.py                    44      0   100%
tests/test_update_metadata.py                     49      0   100%
tests/test_verify_token.py                        32      0   100%
tests/utils.py                                     6      0   100%
------------------------------------------------------------------
TOTAL                                           1312     14    99%
```

### Building Container

```
[14:25 | Fast-metadata-service]$ podman build -t generic-metadata .
STEP 1/5: FROM python:3.9.14-slim-buster
STEP 2/5: WORKDIR /home/project/
--> Using cache 3ebba13fd48784e6f4c65e34c3acfce277ffd825e8a55d870311f92e442638f4
--> 3ebba13fd48
STEP 3/5: COPY . .
--> 67ba1ed0440
STEP 4/5: RUN pip install --no-cache -r requirements.txt;
Collecting PyJWT
  Downloading PyJWT-2.6.0-py3-none-any.whl (20 kB)
Collecting aioboto3==10.3.0
  Downloading aioboto3-10.3.0-py3-none-any.whl (32 kB)
Collecting aiofiles==22.1.0
  Downloading aiofiles-22.1.0-py3-none-any.whl (14 kB)
Collecting fastapi==0.89.1
  Downloading fastapi-0.89.1-py3-none-any.whl (55 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 55.8/55.8 KB 2.6 MB/s eta 0:00:00
Collecting httpx==0.23.3
  Downloading httpx-0.23.3-py3-none-any.whl (71 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 71.5/71.5 KB 5.2 MB/s eta 0:00:00
Collecting uvicorn==0.20.0
  Downloading uvicorn-0.20.0-py3-none-any.whl (56 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 56.9/56.9 KB 4.9 MB/s eta 0:00:00
Collecting aiobotocore[boto3]==2.4.1
  Downloading aiobotocore-2.4.1-py3-none-any.whl (66 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 66.8/66.8 KB 5.0 MB/s eta 0:00:00
Collecting pydantic!=1.7,!=1.7.1,!=1.7.2,!=1.7.3,!=1.8,!=1.8.1,<2.0.0,>=1.6.2
  Downloading pydantic-1.10.7-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (3.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.2/3.2 MB 5.0 MB/s eta 0:00:00
Collecting starlette==0.22.0
  Downloading starlette-0.22.0-py3-none-any.whl (64 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 64.3/64.3 KB 6.1 MB/s eta 0:00:00
Collecting certifi
  Downloading certifi-2022.12.7-py3-none-any.whl (155 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 155.3/155.3 KB 5.8 MB/s eta 0:00:00
Collecting httpcore<0.17.0,>=0.15.0
  Downloading httpcore-0.16.3-py3-none-any.whl (69 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 69.6/69.6 KB 6.7 MB/s eta 0:00:00
Collecting rfc3986[idna2008]<2,>=1.3
  Downloading rfc3986-1.5.0-py2.py3-none-any.whl (31 kB)
Collecting sniffio
  Downloading sniffio-1.3.0-py3-none-any.whl (10 kB)
Collecting h11>=0.8
  Downloading h11-0.14.0-py3-none-any.whl (58 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 58.3/58.3 KB 6.0 MB/s eta 0:00:00
Collecting click>=7.0
  Downloading click-8.1.3-py3-none-any.whl (96 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 96.6/96.6 KB 5.6 MB/s eta 0:00:00
Collecting wrapt>=1.10.10
  Downloading wrapt-1.15.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (78 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 78.3/78.3 KB 5.4 MB/s eta 0:00:00
Collecting aioitertools>=0.5.1
  Downloading aioitertools-0.11.0-py3-none-any.whl (23 kB)
Collecting aiohttp>=3.3.1
  Downloading aiohttp-3.8.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (1.0 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.0/1.0 MB 5.5 MB/s eta 0:00:00
Collecting botocore<1.27.60,>=1.27.59
  Downloading botocore-1.27.59-py3-none-any.whl (9.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 9.1/9.1 MB 4.0 MB/s eta 0:00:00
Collecting boto3<1.24.60,>=1.24.59
  Downloading boto3-1.24.59-py3-none-any.whl (132 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 132.5/132.5 KB 2.9 MB/s eta 0:00:00
Collecting anyio<5,>=3.4.0
  Downloading anyio-3.6.2-py3-none-any.whl (80 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 80.6/80.6 KB 3.5 MB/s eta 0:00:00
Collecting typing-extensions>=3.10.0
  Downloading typing_extensions-4.5.0-py3-none-any.whl (27 kB)
Collecting idna
  Downloading idna-3.4-py3-none-any.whl (61 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 61.5/61.5 KB 6.2 MB/s eta 0:00:00
Collecting aiosignal>=1.1.2
  Downloading aiosignal-1.3.1-py3-none-any.whl (7.6 kB)
Collecting attrs>=17.3.0
  Downloading attrs-22.2.0-py3-none-any.whl (60 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 60.0/60.0 KB 3.8 MB/s eta 0:00:00
Collecting charset-normalizer<4.0,>=2.0
  Downloading charset_normalizer-3.1.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (199 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 199.2/199.2 KB 2.9 MB/s eta 0:00:00
Collecting yarl<2.0,>=1.0
  Downloading yarl-1.8.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (264 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 264.6/264.6 KB 2.8 MB/s eta 0:00:00
Collecting async-timeout<5.0,>=4.0.0a3
  Downloading async_timeout-4.0.2-py3-none-any.whl (5.8 kB)
Collecting frozenlist>=1.1.1
  Downloading frozenlist-1.3.3-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl (158 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 158.8/158.8 KB 2.9 MB/s eta 0:00:00
Collecting multidict<7.0,>=4.5
  Downloading multidict-6.0.4-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (114 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 114.2/114.2 KB 3.6 MB/s eta 0:00:00
Collecting jmespath<2.0.0,>=0.7.1
  Downloading jmespath-1.0.1-py3-none-any.whl (20 kB)
Collecting s3transfer<0.7.0,>=0.6.0
  Downloading s3transfer-0.6.0-py3-none-any.whl (79 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 79.6/79.6 KB 3.5 MB/s eta 0:00:00
Collecting python-dateutil<3.0.0,>=2.1
  Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 KB 2.9 MB/s eta 0:00:00
Collecting urllib3<1.27,>=1.25.4
  Downloading urllib3-1.26.15-py2.py3-none-any.whl (140 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 140.9/140.9 KB 2.7 MB/s eta 0:00:00
Collecting six>=1.5
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: rfc3986, wrapt, urllib3, typing-extensions, sniffio, six, PyJWT, multidict, jmespath, idna, h11, frozenlist, click, charset-normalizer, certifi, attrs, async-timeout, aiofiles, yarl, uvicorn, python-dateutil, pydantic, anyio, aiosignal, aioitertools, starlette, httpcore, botocore, aiohttp, s3transfer, httpx, fastapi, aiobotocore, boto3, aioboto3
Successfully installed PyJWT-2.6.0 aioboto3-10.3.0 aiobotocore-2.4.1 aiofiles-22.1.0 aiohttp-3.8.4 aioitertools-0.11.0 aiosignal-1.3.1 anyio-3.6.2 async-timeout-4.0.2 attrs-22.2.0 boto3-1.24.59 botocore-1.27.59 certifi-2022.12.7 charset-normalizer-3.1.0 click-8.1.3 fastapi-0.89.1 frozenlist-1.3.3 h11-0.14.0 httpcore-0.16.3 httpx-0.23.3 idna-3.4 jmespath-1.0.1 multidict-6.0.4 pydantic-1.10.7 python-dateutil-2.8.2 rfc3986-1.5.0 s3transfer-0.6.0 six-1.16.0 sniffio-1.3.0 starlette-0.22.0 typing-extensions-4.5.0 urllib3-1.26.15 uvicorn-0.20.0 wrapt-1.15.0 yarl-1.8.2
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
WARNING: You are using pip version 22.0.4; however, version 23.0.1 is available.
You should consider upgrading via the '/usr/local/bin/python -m pip install --upgrade pip' command.
--> 8965c9c3578
STEP 5/5: CMD python main.py
COMMIT generic-metadata
--> 2fd5783edad
Successfully tagged localhost/generic-metadata:latest
2fd5783edadd15de367bebaf7ff73607140c0454354c1086de85c6b5a2d88eec
```

### Running Container

```
(env) [14:26 | Fast-metadata-service]$ podman run -it --env-file .env --rm localhost/generic-metadata:latest
INFO:     Started server process [2]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:3000 (Press CTRL+C to quit)
^CINFO:     Shutting down
INFO:     Waiting for application shutdown.
INFO:     Application shutdown complete.
INFO:     Finished server process [2]
(env) [14:26 | Fast-metadata-service]$ podman run -it --env-file .env --env PORT=3999 --rm localhost/generic-metadata:latest
INFO:     Started server process [2]
INFO:     Waiting for application startup.
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:3999 (Press CTRL+C to quit)
```